### PR TITLE
Handle services Unauthorized errors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ NOTE: Kibana can be accessed at http://localhost:5601
 
 It is possible to perform requests to the API using the `Postman` collection and environment present at `postman/` directory, it is only required to import them both.
 
-On the other hand, another example request can be performed via `curl`:
+Requests can also be performed via `curl`:
 
 [source,bash]
 curl http://localhost:8080/developers/connected/dev1/dev2

--- a/src/main/scala/com/github/aldtid/developers/connected/handler/DevelopersHandler.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/handler/DevelopersHandler.scala
@@ -123,6 +123,8 @@ object DevelopersHandler {
         case error                => InternalTwitterError(username, error)
       })
       .flatMap(
+        // In case the user data does not exist, we can assume that the user does not exist (as that
+        // user cannot be requested with current credentials)
         _.data.fold[EitherT[F, Error, Followers]](EitherT.leftT(InvalidTwitterUser(username)))(data =>
           twitter.getUserFollowers(data.id).leftMap(InternalTwitterError(username, _))
         )
@@ -199,6 +201,8 @@ object DevelopersHandler {
       parallel[F, Followers, Followers, List[User]](
         getFollowers(developers.first, twitter).leftMap(NonEmptyList.one),
         getFollowers(developers.second, twitter).leftMap(NonEmptyList.one),
+        // In case the followers list does not exist, we can assume that the user has no followers
+        // (as does followers cannot be requested with current credentials)
         (fol1, fol2) => fol1.data.zip(fol2.data).map(tuple => tuple._1.filter(tuple._2.contains)).getOrElse(Nil)
       )
 

--- a/src/main/scala/com/github/aldtid/developers/connected/service/github/GitHubService.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/service/github/GitHubService.scala
@@ -87,9 +87,10 @@ object GitHubService {
     val baseLog: Log[L] = username.asUsername |+| githubTag
 
     val handle: Response[F] => F[Either[Error, List[Organization]]] = {
-      case Status.Successful(response) => bodyAs[F, List[Organization]](response).map(identity)
-      case Status.NotFound(response)   => util.bodyAs(response, (_, body) => Left(NotFound(body)))
-      case response                    => util.bodyAs(response, (s, b) => Left(UnexpectedResponse(s, b, None)))
+      case Status.Successful(response)   => bodyAs[F, List[Organization]](response).map(identity)
+      case Status.NotFound(response)     => util.bodyAs(response, (_, body) => Left(NotFound(body)))
+      case Status.Unauthorized(response) => util.bodyAs(response, (_, body) => Left(Unauthorized(body)))
+      case response                      => util.bodyAs(response, (s, b) => Left(UnexpectedResponse(s, b, None)))
     }
 
     util.requestWithLogs(request, baseLog |+| githubOrganizationsRequest, baseLog |+| githubOrganizationsResponse, handle)

--- a/src/main/scala/com/github/aldtid/developers/connected/service/github/package.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/service/github/package.scala
@@ -23,6 +23,7 @@ package object github {
 
     sealed trait Error
     final case class NotFound(body: String) extends Error
+    final case class Unauthorized(body: String) extends Error
     final case class UnexpectedResponse(status: Int, body: String, error: Option[CError]) extends Error
 
   }

--- a/src/main/scala/com/github/aldtid/developers/connected/service/twitter/package.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/service/twitter/package.scala
@@ -1,6 +1,6 @@
 package com.github.aldtid.developers.connected.service
 
-import io.circe.{Error => CError}
+import io.circe.{Json, Error => CError}
 import org.http4s.Uri
 
 
@@ -16,18 +16,19 @@ package object twitter {
 
     final case class User(id: String, name: String, username: String)
 
-    final case class UserData(data: User)
+    final case class UserData(data: Option[User], errors: Option[List[Json]])
 
     final case class Meta(resultCount: Long)
 
-    final case class Followers(data: Option[List[User]], meta: Meta)
+    final case class Followers(data: Option[List[User]], meta: Option[Meta], errors: Option[List[Json]])
 
   }
 
   object error {
 
     sealed trait Error
-    final case class NotFound(body: String) extends Error
+    final case class BadRequest(body: String) extends Error
+    final case class Unauthorized(body: String) extends Error
     final case class UnexpectedResponse(status: Int, body: String, error: Option[CError]) extends Error
 
   }

--- a/src/test/scala/com/github/aldtid/developers/connected/logging/JsonTests.scala
+++ b/src/test/scala/com/github/aldtid/developers/connected/logging/JsonTests.scala
@@ -106,41 +106,59 @@ class JsonTests extends AnyFlatSpec with Matchers {
           )
       )
 
-    jsonProgramLog.twitterUserDataLoggable.format(UserData(User("123", "name", "username"))) shouldBe
+    jsonProgramLog.twitterUserDataLoggable.format(UserData(Some(User("123", "name", "username")), None)) shouldBe
       Json.obj(
         "user" -> Json.obj(
-          "id" -> Json.fromString("123"),
-          "name" -> Json.fromString("name"),
-          "username" -> Json.fromString("username")
-        )
-      )
-
-    jsonProgramLog.twitterFollowersLoggable.format(Followers(Some(List(User("123", "name", "username"))), Meta(1))) shouldBe
-      Json.obj(
-        "followers" -> Json.arr(
-          Json.obj(
+          "data" -> Json.obj(
             "id" -> Json.fromString("123"),
             "name" -> Json.fromString("name"),
             "username" -> Json.fromString("username")
-          )
-        ),
-        "meta" -> Json.obj(
-          "resultCount" -> Json.fromInt(1)
+          ),
+          "errors" -> Json.Null
         )
       )
 
-    jsonProgramLog.twitterFollowersLoggable.format(Followers(None, Meta(1))) shouldBe
+    jsonProgramLog.twitterFollowersLoggable.format(Followers(Some(List(User("123", "name", "username"))), Some(Meta(1)), None)) shouldBe
       Json.obj(
-        "followers" -> Json.Null,
-        "meta" -> Json.obj(
-          "resultCount" -> Json.fromInt(1)
+        "followers" -> Json.obj(
+          "data" -> Json.arr(
+            Json.obj(
+              "id" -> Json.fromString("123"),
+              "name" -> Json.fromString("name"),
+              "username" -> Json.fromString("username")
+            )
+          ),
+          "meta" -> Json.obj(
+            "resultCount" -> Json.fromInt(1)
+          ),
+          "errors" -> Json.Null
         )
       )
 
-    jsonProgramLog.twitterErrorLoggable.format(terror.NotFound("body")) shouldBe
+    jsonProgramLog.twitterFollowersLoggable.format(Followers(None, Some(Meta(1)), None)) shouldBe
+      Json.obj(
+        "followers" -> Json.obj(
+          "data" -> Json.Null,
+          "meta" -> Json.obj(
+            "resultCount" -> Json.fromInt(1)
+          ),
+          "errors" -> Json.Null
+        )
+      )
+
+    jsonProgramLog.twitterErrorLoggable.format(terror.BadRequest("body")) shouldBe
       Json.obj(
         "error" -> Json.obj(
-          "notFound" -> Json.obj(
+          "badRequest" -> Json.obj(
+            "body" -> Json.fromString("body")
+          )
+        )
+      )
+
+    jsonProgramLog.twitterErrorLoggable.format(terror.Unauthorized("body")) shouldBe
+      Json.obj(
+        "error" -> Json.obj(
+          "unauthorized" -> Json.obj(
             "body" -> Json.fromString("body")
           )
         )
@@ -170,6 +188,15 @@ class JsonTests extends AnyFlatSpec with Matchers {
           Json.obj(
             "login" -> Json.fromString("login"),
             "id" -> Json.fromInt(123)
+          )
+        )
+      )
+
+    jsonProgramLog.githubErrorLoggable.format(gerror.Unauthorized("body")) shouldBe
+      Json.obj(
+        "error" -> Json.obj(
+          "unauthorized" -> Json.obj(
+            "body" -> Json.fromString("body")
           )
         )
       )
@@ -238,13 +265,13 @@ class JsonTests extends AnyFlatSpec with Matchers {
         )
       )
 
-    errorEncoder.apply(InternalTwitterError("dev1", terror.NotFound("body"))) shouldBe
+    errorEncoder.apply(InternalTwitterError("dev1", terror.BadRequest("body"))) shouldBe
       Json.obj(
         "internal" -> Json.obj(
           "twitter" -> Json.obj(
             "username" -> Json.fromString("dev1"),
             "error" -> Json.obj(
-              "notFound" -> Json.obj(
+              "badRequest" -> Json.obj(
                 "body" -> Json.fromString("body")
               )
             )


### PR DESCRIPTION
Adds `Unauthorized` errors for Twitter and GitHub services, to give some more clarity on logs when requests are incorrect due to an invalid authentication.

Twitter errors are also fixed to correctly return an username as an invalid username when the user and followers requests do not fail but return an `errors` field inside the body.