### PR TITLE
Retrieve following instead of followers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,3 +50,37 @@ Requests can also be performed via `curl`:
 
 [source,bash]
 curl http://localhost:8080/developers/connected/dev1/dev2
+
+== Examples
+
+An example of connected developers is the trio `djspiewak`, `rossabaker` and `milessabin`:
+
+[source,bash]
+$ curl http://localhost:8080/developers/connected/djspiewak/rossabaker
+{"organizations":["typelevel"],"connected":true}
+
+[source,bash]
+$ curl http://localhost:8080/developers/connected/djspiewak/milessabin
+{"organizations":["typelevel"],"connected":true}
+
+[source,bash]
+$ curl http://localhost:8080/developers/connected/rossabaker/milessabin
+{"organizations":["typelevel"],"connected":true}
+
+An example of non-connected developers that share an organization in common is the pair `djspiewak` and `mpilquist`:
+
+[source,bash]
+$ curl http://localhost:8080/developers/connected/djspiewak/mpilquist
+{"connected":false}
+
+An example of non-connected developers that follow each other is the pair `djspiewak` and `odersky`:
+
+[source,bash]
+$ curl http://localhost:8080/developers/connected/djspiewak/odersky
+{"connected":false}
+
+And an example invalid developers is the pair `asdlfkhlas` and `qwoeripu`:
+
+[source,bash]
+$ curl http://localhost:8080/developers/connected/asdlfkhlas/qwoeripu
+{"errors":["asdlfkhlas is not a valid user in github","qwoeripu is not a valid user in github","asdlfkhlas is not a valid user in twitter","qwoeripu is not a valid user in twitter"]}

--- a/src/main/scala/com/github/aldtid/developers/connected/application.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/application.scala
@@ -88,8 +88,7 @@ object application {
 
       case GET -> Root / "developers" / "connected" / dev1 / dev2 =>
         controller.checkConnection(Developers(dev1, dev2))
-          .leftMap(errors => BadRequest(errors.encode))
-          .map(connection => Ok(connection.encode))
+          .bimap(errors => Ok(errors.encode), connection => Ok(connection.encode))
           .foldF(identity, identity)
 
     }

--- a/src/main/scala/com/github/aldtid/developers/connected/launcher.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/launcher.scala
@@ -3,7 +3,7 @@ package com.github.aldtid.developers.connected
 import com.github.aldtid.developers.connected.configuration._
 import com.github.aldtid.developers.connected.encoder.BodyEncoder
 import com.github.aldtid.developers.connected.handler.DevelopersHandler
-import com.github.aldtid.developers.connected.handler.DevelopersHandler.{Cache, UserFollowers}
+import com.github.aldtid.developers.connected.handler.DevelopersHandler.{Cache, UserFollowing}
 import com.github.aldtid.developers.connected.logging.{Log, ProgramLog}
 import com.github.aldtid.developers.connected.logging.implicits.all._
 import com.github.aldtid.developers.connected.logging.messages._
@@ -117,7 +117,7 @@ object launcher {
 
           val timeout: FiniteDuration = config.cache.timeoutSeconds.seconds
 
-          def handler(orgsCache: Cache[F, String, List[Organization]], folCache: Cache[F, String, UserFollowers]): DevelopersHandler[F] =
+          def handler(orgsCache: Cache[F, String, List[Organization]], folCache: Cache[F, String, UserFollowing]): DevelopersHandler[F] =
             DevelopersHandler.default[F, L](GitHubService.default, TwitterService.default, orgsCache, folCache, timeout)
 
           for {
@@ -127,7 +127,7 @@ object launcher {
             _          <- Logger[F].info(baseLog |+| startingServer |+| config.server)
 
             orgsCache  <- TempCache.createCache[F, String, Either[NonEmptyList[Error], List[Organization]]]
-            folCache   <- TempCache.createCache[F, String, Either[NonEmptyList[Error], UserFollowers]]
+            folCache   <- TempCache.createCache[F, String, Either[NonEmptyList[Error], UserFollowing]]
             devHandler  = handler(TempCache.default(orgsCache), TempCache.default(folCache))
 
             code       <- start[F, L, O](serverEC, config.server, devHandler)

--- a/src/main/scala/com/github/aldtid/developers/connected/logging/ProgramLog.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/logging/ProgramLog.scala
@@ -52,7 +52,7 @@ trait ProgramLog[L] {
 
   // Supported Twitter model types
   implicit val twitterUserDataLoggable: Loggable[UserData, L]
-  implicit val twitterFollowersLoggable: Loggable[Followers, L]
+  implicit val twitterFollowingLoggable: Loggable[Following, L]
   implicit val twitterErrorLoggable: Loggable[TError, L]
   implicit val twitterConnectionLoggable: Loggable[TwitterConnection, L]
 

--- a/src/main/scala/com/github/aldtid/developers/connected/logging/json.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/logging/json.scala
@@ -8,7 +8,7 @@ import com.github.aldtid.developers.connected.service.github.connection.GitHubCo
 import com.github.aldtid.developers.connected.service.github.response.Organization
 import com.github.aldtid.developers.connected.service.github.{error => gerror}
 import com.github.aldtid.developers.connected.service.twitter.connection.TwitterConnection
-import com.github.aldtid.developers.connected.service.twitter.response.{Followers, UserData}
+import com.github.aldtid.developers.connected.service.twitter.response.{Following, UserData}
 import com.github.aldtid.developers.connected.service.twitter.{error => terror}
 
 import io.circe.{Encoder, Json, Printer, Error => CError}
@@ -77,10 +77,10 @@ object json {
         )
       )
 
-  val jsonTwitterFollowersLoggable: Loggable[Followers, Json] =
+  val jsonTwitterFollowingLoggable: Loggable[Following, Json] =
     followers =>
       Json.obj(
-        "followers" -> Json.obj(
+        "following" -> Json.obj(
           "data" -> followers.data.asJson,
           "meta" -> followers.meta.asJson,
           // Convert the errors to strings and add them to the object as a list
@@ -191,7 +191,7 @@ object json {
     implicit val errorsLoggable: Loggable[Errors, Json] = jsonErrorsLoggable
 
     implicit val twitterUserDataLoggable: Loggable[UserData, Json] = jsonTwitterUserDataLoggable
-    implicit val twitterFollowersLoggable: Loggable[Followers, Json] = jsonTwitterFollowersLoggable
+    implicit val twitterFollowingLoggable: Loggable[Following, Json] = jsonTwitterFollowingLoggable
     implicit val twitterErrorLoggable: Loggable[terror.Error, Json] = jsonTwitterErrorLoggable
     implicit val twitterConnectionLoggable: Loggable[TwitterConnection, Json] = jsonTwitterConnectionLoggable
 

--- a/src/main/scala/com/github/aldtid/developers/connected/logging/messages.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/logging/messages.scala
@@ -35,10 +35,10 @@ object messages {
   val twitterUserSuccess: Message = "user retrieved".asMessage
   val twitterUserError: Message = "user could not be retrieved".asMessage
 
-  val twitterFollowersRequest: Message = "requesting user followers".asMessage
-  val twitterFollowersResponse: Message = "response for requested followers".asMessage
-  val twitterFollowersSuccess: Message = "user followers retrieved".asMessage
-  val twitterFollowersError: Message = "user followers could not be retrieved".asMessage
+  val twitterFollowingRequest: Message = "requesting following users".asMessage
+  val twitterFollowingResponse: Message = "response for requested following users".asMessage
+  val twitterFollowingSuccess: Message = "following users retrieved".asMessage
+  val twitterFollowingError: Message = "following users could not be retrieved".asMessage
 
   // ----- GITHUB SERVICE -----
   val githubOrganizationsRequest: Message = "requesting user organizations".asMessage

--- a/src/main/scala/com/github/aldtid/developers/connected/service/twitter/package.scala
+++ b/src/main/scala/com/github/aldtid/developers/connected/service/twitter/package.scala
@@ -20,7 +20,7 @@ package object twitter {
 
     final case class Meta(resultCount: Long)
 
-    final case class Followers(data: Option[List[User]], meta: Option[Meta], errors: Option[List[Json]])
+    final case class Following(data: Option[List[User]], meta: Option[Meta], errors: Option[List[Json]])
 
   }
 

--- a/src/test/scala/com/github/aldtid/developers/connected/ApplicationTests.scala
+++ b/src/test/scala/com/github/aldtid/developers/connected/ApplicationTests.scala
@@ -48,7 +48,7 @@ class ApplicationTests extends AnyFlatSpec with Matchers {
     val headers: Headers = Headers(`Content-Type`(MediaType.application.json), `Content-Length`(body.length))
     val response: Response[Id] = developers[Id, Json, Json](handler).apply(Request(uri = uri"/developers/connected/dev1/dev"))
 
-    response.status shouldBe Status.BadRequest
+    response.status shouldBe Status.Ok
     response.headers shouldBe headers
     response.body.compile.toList shouldBe body.getBytes
 

--- a/src/test/scala/com/github/aldtid/developers/connected/handler/DevelopersHandlerTests.scala
+++ b/src/test/scala/com/github/aldtid/developers/connected/handler/DevelopersHandlerTests.scala
@@ -136,19 +136,19 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         if (username == "dev") EitherT.rightT(UserData(Some(User("id", "name", username)), None))
         else EitherT.leftT(terror.BadRequest("body"))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
-        if (id == "id") EitherT.rightT(Followers(Some(List(User(id, "name", "username"))), None, None))
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
+        if (id == "id") EitherT.rightT(Following(Some(List(User(id, "name", "username"))), None, None))
         else EitherT.leftT(terror.BadRequest("body"))
 
     }
 
-    getFollowers("dev", service).value.unsafeRunSync() shouldBe
-      Right(UserFollowers(User("id", "name", "dev"), Followers(Some(List(User("id", "name", "username"))), None, None)))
+    getFollowing("dev", service).value.unsafeRunSync() shouldBe
+      Right(UserFollowing(User("id", "name", "dev"), Following(Some(List(User("id", "name", "username"))), None, None)))
 
   }
 
@@ -169,17 +169,17 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         if (username == "dev") EitherT.leftT(terror.BadRequest("body"))
         else EitherT.rightT(UserData(Some(User("id", "name", username)), None))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
-        EitherT.rightT(Followers(Some(List(User(id, "name", "username"))), None, None))
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
+        EitherT.rightT(Following(Some(List(User(id, "name", "username"))), None, None))
 
     }
 
-    getFollowers("dev", service).value.unsafeRunSync() shouldBe Left(InvalidTwitterUser("dev"))
+    getFollowing("dev", service).value.unsafeRunSync() shouldBe Left(InvalidTwitterUser("dev"))
 
   }
 
@@ -200,17 +200,17 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         if (username == "dev") EitherT.leftT(terror.Unauthorized("body"))
         else EitherT.rightT(UserData(Some(User("id", "name", username)), None))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
-        EitherT.rightT(Followers(Some(List(User(id, "name", "username"))), None, None))
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
+        EitherT.rightT(Following(Some(List(User(id, "name", "username"))), None, None))
 
     }
 
-    getFollowers("dev", service).value.unsafeRunSync() shouldBe
+    getFollowing("dev", service).value.unsafeRunSync() shouldBe
       Left(InternalTwitterError("dev", terror.Unauthorized("body")))
 
   }
@@ -232,17 +232,17 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         if (username == "dev") EitherT.rightT(UserData(None, None))
         else EitherT.leftT(terror.Unauthorized("body"))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
-        EitherT.rightT(Followers(Some(List(User(id, "name", "username"))), None, None))
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
+        EitherT.rightT(Following(Some(List(User(id, "name", "username"))), None, None))
 
     }
 
-    getFollowers("dev", service).value.unsafeRunSync() shouldBe Left(InvalidTwitterUser("dev"))
+    getFollowing("dev", service).value.unsafeRunSync() shouldBe Left(InvalidTwitterUser("dev"))
 
   }
 
@@ -263,18 +263,18 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         if (username == "dev") EitherT.rightT(UserData(Some(User("id", "name", username)), None))
         else EitherT.leftT(terror.BadRequest("body"))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
         if (id == "id") EitherT.leftT(terror.Unauthorized("body"))
-        else EitherT.rightT(Followers(Some(List(User(id, "name", "username"))), None, None))
+        else EitherT.rightT(Following(Some(List(User(id, "name", "username"))), None, None))
 
     }
 
-    getFollowers("dev", service).value.unsafeRunSync() shouldBe
+    getFollowing("dev", service).value.unsafeRunSync() shouldBe
       Left(InternalTwitterError("dev", terror.Unauthorized("body")))
 
   }
@@ -377,8 +377,8 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
 
     val user1: User = User("id1", "name1", "dev1")
     val user2: User = User("id2", "name2", "dev2")
-    val followers1: Followers = Followers(Some(List(user2)), None, None)
-    val followers2: Followers = Followers(Some(List(user1)), None, None)
+    val followers1: Following = Following(Some(List(user2)), None, None)
+    val followers2: Following = Following(Some(List(user1)), None, None)
 
     val twService: TwitterService[IO] = new TwitterService[IO] {
 
@@ -392,12 +392,12 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         else if (username == "dev2") EitherT.rightT(UserData(Some(user2), None))
         else EitherT.leftT(terror.BadRequest("body"))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
         if (id == "id1") EitherT.rightT(followers1)
         else if (id == "id2") EitherT.rightT(followers2)
         else EitherT.leftT(terror.BadRequest("body"))
@@ -409,7 +409,7 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
 
         orgsCache <- createCache[IO, String, Either[NonEmptyList[Error], List[Organization]]]
         orgsTemp   = TempCache.default(orgsCache)
-        folCache  <- createCache[IO, String, Either[NonEmptyList[Error], UserFollowers]]
+        folCache  <- createCache[IO, String, Either[NonEmptyList[Error], UserFollowing]]
         folTemp    = TempCache.default(folCache)
 
         result    <- checkConnection(ghService, twService, orgsTemp, folTemp, 5.seconds, Developers("dev1", "dev2")).value
@@ -425,8 +425,8 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
           "dev2" -> CacheValue(Right(List(organization1, organization3)), 5.seconds)
         ),
         Map(
-          "dev1" -> CacheValue(Right(UserFollowers(user1, followers1)), 5.seconds),
-          "dev2" -> CacheValue(Right(UserFollowers(user2, followers2)), 5.seconds)
+          "dev1" -> CacheValue(Right(UserFollowing(user1, followers1)), 5.seconds),
+          "dev2" -> CacheValue(Right(UserFollowing(user2, followers2)), 5.seconds)
         )
       )
 
@@ -460,8 +460,8 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
 
     val user1: User = User("id1", "name1", "dev1")
     val user2: User = User("id2", "name2", "dev2")
-    val followers1: Followers = Followers(Some(List(user2)), None, None)
-    val followers2: Followers = Followers(Some(List(user1)), None, None)
+    val followers1: Following = Following(Some(List(user2)), None, None)
+    val followers2: Following = Following(Some(List(user1)), None, None)
 
     val twService: TwitterService[IO] = new TwitterService[IO] {
 
@@ -475,12 +475,12 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         else if (username == "dev2") EitherT.rightT(UserData(Some(user2), None))
         else EitherT.leftT(terror.BadRequest("body"))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
         if (id == "id1") EitherT.rightT(followers1)
         else if (id == "id2") EitherT.rightT(followers2)
         else EitherT.leftT(terror.BadRequest("body"))
@@ -492,7 +492,7 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
 
         orgsCache <- createCache[IO, String, Either[NonEmptyList[Error], List[Organization]]]
         orgsTemp   = TempCache.default(orgsCache)
-        folCache  <- createCache[IO, String, Either[NonEmptyList[Error], UserFollowers]]
+        folCache  <- createCache[IO, String, Either[NonEmptyList[Error], UserFollowing]]
         folTemp    = TempCache.default(folCache)
 
         result    <- checkConnection(ghService, twService, orgsTemp, folTemp, 5.seconds, Developers("dev1", "dev2")).value
@@ -508,8 +508,8 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         "dev2" -> CacheValue(Right(List(organization3)), 5.seconds)
       ),
       Map(
-        "dev1" -> CacheValue(Right(UserFollowers(user1, followers1)), 5.seconds),
-        "dev2" -> CacheValue(Right(UserFollowers(user2, followers2)), 5.seconds)
+        "dev1" -> CacheValue(Right(UserFollowing(user1, followers1)), 5.seconds),
+        "dev2" -> CacheValue(Right(UserFollowing(user2, followers2)), 5.seconds)
       )
     )
 
@@ -543,8 +543,8 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
 
     val user1: User = User("id1", "name1", "dev1")
     val user2: User = User("id2", "name2", "dev2")
-    val followers1: Followers = Followers(Some(List(user2)), None, None)
-    val followers2: Followers = Followers(None, None, None)
+    val followers1: Following = Following(Some(List(user2)), None, None)
+    val followers2: Following = Following(None, None, None)
 
     val twService: TwitterService[IO] = new TwitterService[IO] {
 
@@ -558,12 +558,12 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         else if (username == "dev2") EitherT.rightT(UserData(Some(user2), None))
         else EitherT.leftT(terror.BadRequest("body"))
 
-      def getUserFollowers[L: ProgramLog](id: String)
+      def getUserFollowing[L: ProgramLog](id: String)
                                          (implicit F: Concurrent[IO],
                                           C: Clock[IO],
                                           client: Client[IO],
                                           logger: Logger[IO],
-                                          connection: TwitterConnection): EitherT[IO, terror.Error, Followers] =
+                                          connection: TwitterConnection): EitherT[IO, terror.Error, Following] =
         if (id == "id1") EitherT.rightT(followers1)
         else if (id == "id2") EitherT.rightT(followers2)
         else EitherT.leftT(terror.BadRequest("body"))
@@ -575,7 +575,7 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
 
         orgsCache <- createCache[IO, String, Either[NonEmptyList[Error], List[Organization]]]
         orgsTemp   = TempCache.default(orgsCache)
-        folCache  <- createCache[IO, String, Either[NonEmptyList[Error], UserFollowers]]
+        folCache  <- createCache[IO, String, Either[NonEmptyList[Error], UserFollowing]]
         folTemp    = TempCache.default(folCache)
 
         result    <- checkConnection(ghService, twService, orgsTemp, folTemp, 5.seconds, Developers("dev1", "dev2")).value
@@ -591,8 +591,8 @@ class DevelopersHandlerTests extends AnyFlatSpec with Matchers {
         "dev2" -> CacheValue(Right(List(organization1, organization3)), 5.seconds)
       ),
       Map(
-        "dev1" -> CacheValue(Right(UserFollowers(user1, followers1)), 5.seconds),
-        "dev2" -> CacheValue(Right(UserFollowers(user2, followers2)), 5.seconds)
+        "dev1" -> CacheValue(Right(UserFollowing(user1, followers1)), 5.seconds),
+        "dev2" -> CacheValue(Right(UserFollowing(user2, followers2)), 5.seconds)
       )
     )
 

--- a/src/test/scala/com/github/aldtid/developers/connected/logging/JsonTests.scala
+++ b/src/test/scala/com/github/aldtid/developers/connected/logging/JsonTests.scala
@@ -5,7 +5,7 @@ import com.github.aldtid.developers.connected.logging.model._
 import com.github.aldtid.developers.connected.service.github.{error => gerror}
 import com.github.aldtid.developers.connected.service.github.response.Organization
 import com.github.aldtid.developers.connected.service.twitter.{error => terror}
-import com.github.aldtid.developers.connected.service.twitter.response.{Followers, Meta, User, UserData}
+import com.github.aldtid.developers.connected.service.twitter.response.{Following, Meta, User, UserData}
 import cats.Id
 import cats.data.NonEmptyList
 import com.github.aldtid.developers.connected.configuration.Server
@@ -118,9 +118,9 @@ class JsonTests extends AnyFlatSpec with Matchers {
         )
       )
 
-    jsonProgramLog.twitterFollowersLoggable.format(Followers(Some(List(User("123", "name", "username"))), Some(Meta(1)), None)) shouldBe
+    jsonProgramLog.twitterFollowingLoggable.format(Following(Some(List(User("123", "name", "username"))), Some(Meta(1)), None)) shouldBe
       Json.obj(
-        "followers" -> Json.obj(
+        "following" -> Json.obj(
           "data" -> Json.arr(
             Json.obj(
               "id" -> Json.fromString("123"),
@@ -135,9 +135,9 @@ class JsonTests extends AnyFlatSpec with Matchers {
         )
       )
 
-    jsonProgramLog.twitterFollowersLoggable.format(Followers(None, Some(Meta(1)), None)) shouldBe
+    jsonProgramLog.twitterFollowingLoggable.format(Following(None, Some(Meta(1)), None)) shouldBe
       Json.obj(
-        "followers" -> Json.obj(
+        "following" -> Json.obj(
           "data" -> Json.Null,
           "meta" -> Json.obj(
             "resultCount" -> Json.fromInt(1)

--- a/src/test/scala/com/github/aldtid/developers/connected/service/twitter/TwitterServiceTests.scala
+++ b/src/test/scala/com/github/aldtid/developers/connected/service/twitter/TwitterServiceTests.scala
@@ -134,11 +134,11 @@ class TwitterServiceTests extends AnyFlatSpec with Matchers {
 
   }
 
-  "getUserFollowers" should "correctly decode an Ok response as expected" in {
+  "getUserFollowing" should "correctly decode an Ok response as expected" in {
 
     val baseUri: Uri = Uri() / "root"
 
-    val expectedUri: Uri = Uri.unsafeFromString("/root/users/user/followers")
+    val expectedUri: Uri = Uri.unsafeFromString("/root/users/user/following?max_results=1000")
     val expectedHeaders: Headers = Headers(Raw(CIString("Authorization"), "Bearer token"))
 
     val body: String = """{"data":[{"id":"123","name":"user-name","username":"user-username"}],"meta":{"result_count":1}}"""
@@ -157,8 +157,8 @@ class TwitterServiceTests extends AnyFlatSpec with Matchers {
     implicit val connection: TwitterConnection = TwitterConnection(baseUri, "token")
     implicit val client: Client[IO] = Client[IO](behavior)
 
-    getUserFollowers[IO, Json]("user").unsafeRunSync() shouldBe
-      Right(Followers(Some(List(User("123","user-name", "user-username"))), Some(Meta(1)), None))
+    getUserFollowing[IO, Json]("user").unsafeRunSync() shouldBe
+      Right(Following(Some(List(User("123","user-name", "user-username"))), Some(Meta(1)), None))
 
   }
 
@@ -166,7 +166,7 @@ class TwitterServiceTests extends AnyFlatSpec with Matchers {
 
     val baseUri: Uri = Uri() / "root"
 
-    val expectedUri: Uri = Uri.unsafeFromString("/root/users/user/followers")
+    val expectedUri: Uri = Uri.unsafeFromString("/root/users/user/following?max_results=1000")
     val expectedHeaders: Headers = Headers(Raw(CIString("Authorization"), "Bearer token"))
 
     val body: String = """{"error":"some error"}"""
@@ -185,7 +185,7 @@ class TwitterServiceTests extends AnyFlatSpec with Matchers {
     implicit val connection: TwitterConnection = TwitterConnection(baseUri, "token")
     implicit val client: Client[IO] = Client[IO](behavior)
 
-    getUserFollowers[IO, Json]("user").unsafeRunSync() shouldBe Left(UnexpectedResponse(400, body, None))
+    getUserFollowing[IO, Json]("user").unsafeRunSync() shouldBe Left(UnexpectedResponse(400, body, None))
 
   }
 


### PR DESCRIPTION
Change the followers retrieve by following retrieve, which is a more efficient operation and involves less potential pagination (when implemented). Also adds connection examples.